### PR TITLE
Make LMDB writer work even w/o transcriptions

### DIFF
--- a/user_scripts/parse_folder.py
+++ b/user_scripts/parse_folder.py
@@ -96,12 +96,13 @@ class LMDB_writer(object):
             all_lines = list(page_layout.lines_iterator())
             all_lines = sorted(all_lines, key=lambda x: x.id)
             for line in all_lines:
+                key = f'{file_id}-{line.id}.jpg'
+                img = cv2.imencode('.jpg', line.crop.astype(np.uint8), [int(cv2.IMWRITE_JPEG_QUALITY), 95])[1].tobytes()
+                self.data_size += len(img)
+                c_out.put(key.encode(), img)
+
                 if line.transcription:
-                    key = f'{file_id}-{line.id}.jpg'
-                    img = cv2.imencode('.jpg', line.crop.astype(np.uint8), [int(cv2.IMWRITE_JPEG_QUALITY), 95])[1].tobytes()
                     print(key, line.transcription, file=self.file)
-                    self.data_size += len(img)
-                    c_out.put(key.encode(), img)
 
 
 def main():


### PR DESCRIPTION
This allows to extract lines even when no OCR is available. Surely useful when constructing new datasets for training OCRs.