### PR TITLE
Simplify code which checks for numba

### DIFF
--- a/pero_ocr/utils.py
+++ b/pero_ocr/utils.py
@@ -3,11 +3,8 @@ import sys
 import subprocess
 
 try:
-    subprocess.check_output(
-        '{} -c "import numba"'.format(sys.executable), shell=True
-    )
-    print('numba available, importing jit')
     from numba import jit
+    print('numba available, importing jit')
 except Exception:
     print('cannot import numba, creating dummy jit definition')
 


### PR DESCRIPTION
It is not necessary to run a subprocess to check whether numba
can be imported.

Signed-off-by: Stefan Weil <sw@weilnetz.de>