### PR TITLE
Fix date format

### DIFF
--- a/pero_ocr/document_ocr/layout.py
+++ b/pero_ocr/document_ocr/layout.py
@@ -221,7 +221,7 @@ class PageLayout(object):
 
             metadata = ET.SubElement(root, "Metadata")
             ET.SubElement(metadata, "Creator").text = creator
-            now = datetime.now()
+            now = datetime.now(datetime.timezone.utc)
             ET.SubElement(metadata, "Created").text = now.isoformat()
             ET.SubElement(metadata, "LastChange").text = now.isoformat()
 
@@ -784,7 +784,7 @@ def create_ocr_processing_element(id="IdOcr", software_creator_str="Project PERO
     if processing_datetime is not None:
         processing_date_time.text = processing_datetime
     else:
-        processing_date_time.text = datetime.today().isoformat()
+        processing_date_time.text = datetime.now(datetime.timezone.utc).isoformat()
     processing_software = ET.SubElement(ocr_processing_step, "processingSoftware")
     processing_creator = ET.SubElement(processing_software, "softwareCreator")
     processing_creator.text = software_creator_str

--- a/pero_ocr/document_ocr/layout.py
+++ b/pero_ocr/document_ocr/layout.py
@@ -784,7 +784,7 @@ def create_ocr_processing_element(id="IdOcr", software_creator_str="Project PERO
     if processing_datetime is not None:
         processing_date_time.text = processing_datetime
     else:
-        processing_date_time.text = datetime.today().strftime('%Y-%m-%d')
+        processing_date_time.text = datetime.today().isoformat()
     processing_software = ET.SubElement(ocr_processing_step, "processingSoftware")
     processing_creator = ET.SubElement(processing_software, "softwareCreator")
     processing_creator.text = software_creator_str


### PR DESCRIPTION
Fixed time format to iso8601 in to_altoxml_string.
Added utc timezone to all timestamps to prevent wrong timestamps due to processing locality.